### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ Then run `composer install`
 
 ### Manual Installation
 
-Download the files and include `autoload.php`:
+Download the files and run `composer install`.
 
-```php
-require_once('/path/to/MXClient-php/vendor/autoload.php');
-```
+The `composer.lock` and `/vendor` directory including `autoload.php` will be generated.
 
 ## Example Usage
 


### PR DESCRIPTION
Updates readme clarifying that `composer install` needs to be ran if
manually installing the library to generate /vendor and autoload.php.